### PR TITLE
remove exception from addDirective method

### DIFF
--- a/src/LTDBeget/apacheConfigurator/ConfigurationFile.php
+++ b/src/LTDBeget/apacheConfigurator/ConfigurationFile.php
@@ -59,8 +59,9 @@ class ConfigurationFile implements iConfigurationFile
 
         $directivePath = $context->getPath()->makeChildDirectivePath($directiveName, $value);
 
-        if($this->findByPath($directivePath)) {
-            throw new WrongDirectivePathFormat("Directive already exists by path: ".json_encode($directivePath->getPath()));
+        // if identical directive already exists, return it, without adding it again
+        if($existDirective = $this->findByPath($directivePath)) {
+            return $existDirective;
         }
 
         $className = __NAMESPACE__."\\directives\\available\\".$directivePath->getDirectiveType();


### PR DESCRIPTION
Because it isn't error. If identical directive already exists, ignore adding it again, and return existing identical directive. 
